### PR TITLE
Support for Sub Protocols. Closes #4

### DIFF
--- a/WebSocket.Portable/WebSocket.Portable/Interfaces/IWebSocket.cs
+++ b/WebSocket.Portable/WebSocket.Portable/Interfaces/IWebSocket.cs
@@ -13,6 +13,12 @@ namespace WebSocket.Portable.Interfaces
         void RegisterExtension(IWebSocketExtension extension);
 
         /// <summary>
+        /// Sets the SubProtocol for this websocket instance
+        /// </summary>
+        /// <param name="subProtocol">The SubProtocol</param>
+        void SetSubProtocol(string subProtocol);
+
+        /// <summary>
         /// Closes the socket asynchronous.
         /// </summary>
         /// <returns></returns>

--- a/WebSocket.Portable/WebSocket.Portable/_Abstract/WebSocketBase.cs
+++ b/WebSocket.Portable/WebSocket.Portable/_Abstract/WebSocketBase.cs
@@ -17,6 +17,7 @@ namespace WebSocket.Portable
     public abstract class WebSocketBase : ICanLog, IWebSocket
     {
         private readonly List<IWebSocketExtension> _extensions;
+        private string _subProtocol;
         private Uri _uri;
         private int _state;
         private ITcpConnection _tcp;
@@ -43,6 +44,11 @@ namespace WebSocket.Portable
                 throw new InvalidOperationException(ErrorMessages.InvalidState + _state);
 
             _extensions.Add(extension);
+        }
+
+        public void SetSubProtocol(string subProtocol)
+        {
+            _subProtocol = subProtocol;
         }
 
         public virtual Task CloseAsync(WebSocketErrorCode errorCode)
@@ -118,6 +124,11 @@ namespace WebSocket.Portable
             foreach (var extension in _extensions)
                 handshake.AddExtension(extension);
 
+            if (!string.IsNullOrEmpty(_subProtocol))
+            {
+                handshake.SecWebSocketProtocol = new[] {_subProtocol};
+            }
+            
             return this.SendHandshakeAsync(handshake, cancellationToken);
         }
 

--- a/WebSocket.Portable/WebSocket.Portable/_Abstract/WebSocketClientBase.cs
+++ b/WebSocket.Portable/WebSocket.Portable/_Abstract/WebSocketClientBase.cs
@@ -11,6 +11,7 @@ namespace WebSocket.Portable
     public abstract class WebSocketClientBase<TWebSocket> : IDisposable, ICanLog
         where TWebSocket : class, IWebSocket, new()
     {
+        private readonly string _subProtocol;
         protected TWebSocket _webSocket;
         private CancellationTokenSource _cts;
         private int _maxFrameDataLength = Consts.MaxDefaultFrameDataLength;
@@ -25,6 +26,12 @@ namespace WebSocket.Portable
         {
             this.AutoSendPongResponse = true;
         }
+
+        protected WebSocketClientBase(string subProtocol) : this()
+        {
+            _subProtocol = subProtocol;
+        }
+
         ~WebSocketClientBase()
         {
             this.Dispose(false);
@@ -95,6 +102,12 @@ namespace WebSocket.Portable
                 throw new InvalidOperationException("Client has been opened before.");
 
             _webSocket = new TWebSocket();
+
+            if (!string.IsNullOrEmpty(_subProtocol))
+            {
+                _webSocket.SetSubProtocol(_subProtocol);
+            }
+
             await _webSocket.ConnectAsync(uri, port, useSSL, cancellationToken);
             await _webSocket.SendHandshakeAsync(cancellationToken);
             this.ReceiveLoop();


### PR DESCRIPTION
Add ability to set the WebSocket Sub Protocol when creating a WebSocketClient.

The WebSocket specification allows for more than one sub protocol, but the decision to allow just one was made as this is analogous to the functionality provided by the .NET `System.Net.WebSockets.WebSocket`, which supports a single sub protocol.
